### PR TITLE
Update meta tag viewport placement

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,4 @@
+import Head from 'next/head'
 import React, { useEffect } from 'react'
 import theme from '../components/theme'
 import Header from '../components/Header'
@@ -39,6 +40,13 @@ export default function MyApp({ Component, pageProps }) {
 
   return (
     <PWA errorReporter={reportError}>
+      <Head>
+        {/* <meta
+          key="viewport"
+          name="viewport"
+          content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
+        /> */}
+      </Head>
       <AmpProvider>
         <SessionProvider url="/api/session">
           <MuiThemeProvider theme={theme}>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,11 +12,6 @@ class MyDocument extends Document {
       <html lang="en">
         <Head>
           <meta charSet="utf-8" />
-          {/* <meta
-            key="viewport"
-            name="viewport"
-            content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
-          /> */}
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
           <link rel="preconnect" href="https://opt.moovweb.net" crossOrigin="true" />


### PR DESCRIPTION
Per https://github.com/vercel/next.js/blob/master/errors/no-document-viewport-meta.md, this tag should be placed in _app.js, not _document.js.