### PR TITLE
Fix: Cart Item Cannot be Updated From Cart Page

### DIFF
--- a/pages/api/cart/update.js
+++ b/pages/api/cart/update.js
@@ -1,6 +1,7 @@
 import { updateCartItem } from 'react-storefront-connector'
+import withAmpFormParser from 'react-storefront/middlewares/withAmpFormParser'
 
-export default async function handler(req, res) {
+async function handler(req, res) {
   const { item, quantity } = req.body
   res.json(await updateCartItem(item, quantity, req, res))
 }
@@ -10,3 +11,5 @@ export const config = {
     bodyParser: true,
   },
 }
+
+export default withAmpFormParser(handler)


### PR DESCRIPTION
When we try to update a cart item from the cart page, it will throw 500 error and the app some time become irresponsive